### PR TITLE
Fix Breaking the Bank at Caligula's

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -94,7 +94,8 @@ Patterns = [
 	{ thread = "truth2", weapon = 37, allowed = [37]},
 	{ thread = "truth2", weapon = 35, allowed = [35, 36, 38]},
 	{ thread = "des10", ped = 0, allowed = [28, 32]},
-	{ thread = "casino9", weapon = 22, allowed = [22, 23, 24]}
+	{ thread = "casino9", weapon = 22, allowed = [22, 23, 24]},
+	{ thread = "heist9", ped = 0, weapon = 17, allowed = [17]}
 ]
 
 #######################################################


### PR DESCRIPTION
Mission instantly failed because you didn't have tear gas.